### PR TITLE
fix: Fix building-o and minus-circle icons

### DIFF
--- a/icons/building-o.svg
+++ b/icons/building-o.svg
@@ -1,4 +1,5 @@
-<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fill-rule="evenodd"
-        d="M5 4c0-1.106.898-2 2.001-2H17C18.102 2 19 2.894 19 4v16h2v2H3v-2h2V4zm12 4v3H7V8h10zM7 13h10v7h-3v-3.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5V20H7v-7zm10-7V4H7v2h10z" />
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<path d="M19,20V4c0-1.1-0.9-2-2-2H7C5.9,2,5,2.9,5,4v16H3v2h18v-2H19z M17,20h-3v-3.5c0-0.3-0.2-0.5-0.5-0.5h-3
+	c-0.3,0-0.5,0.2-0.5,0.5V20H7v-7h10V20z M17,11H7V8h10V11z M17,6H7V4l0,0h0h10h0l0,0V6z"/>
 </svg>

--- a/icons/minus-circle.svg
+++ b/icons/minus-circle.svg
@@ -1,3 +1,4 @@
-<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fill-rule="evenodd" d="M20.5 12a8.5 8.5 0 1 1-17 0 8.5 8.5 0 0 1 17 0zM8 11.25v1.5h8v-1.5H8z" />
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<path d="M12,3.5c-4.7,0-8.5,3.8-8.5,8.5s3.8,8.5,8.5,8.5s8.5-3.8,8.5-8.5S16.7,3.5,12,3.5z M16,12.8H8v-1.5h8V12.8z"/>
 </svg>


### PR DESCRIPTION
The icons were not resizing correctly